### PR TITLE
feat(ignore): Add new ignore option to allow to exclude matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ globPlugin({
   controls: false,
   // Disables logging on file changes
   silent: false,
+  // An array of glob patterns to exclude matches
+  ignore: []
 })
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,13 @@ interface GlobPluginOptions<TControls extends boolean> {
   /** Disables all logging */
   silent?: boolean;
   additionalEntrypoints?: string[];
+  /**
+   * An array of glob patterns to exclude matches.
+   * This is an alternative way to use negative patterns.
+   *
+   * @default []
+   */
+  ignore?: fastGlob.Options['ignore'];
 }
 
 interface GlobPluginControls {
@@ -30,6 +37,7 @@ function globPlugin<TControls extends boolean = false>({
   controls,
   silent = false,
   additionalEntrypoints = [],
+  ignore = [],
 }: GlobPluginOptions<TControls> = {}): ReturnValue<TControls> {
   const log = createLogger(silent);
 
@@ -173,7 +181,7 @@ function globPlugin<TControls extends boolean = false>({
       } else {
         const entryGlobs = [...build.initialOptions.entryPoints, ...additionalEntrypoints];
         const resolvedEntryPoints = await Promise.all(
-          entryGlobs.map((entryPoint) => fastGlob(entryPoint)),
+          entryGlobs.map((entryPoint) => fastGlob(entryPoint, { ignore })),
         ).then((nestedEntryPoints) => nestedEntryPoints.flat());
         build.initialOptions.entryPoints = resolvedEntryPoints;
       }


### PR DESCRIPTION
I need a way to define to glob patterns to exclude matches.
The package `fast-glob` already has an option `ignore` for this, so I have added this option to the plugin options and just pass it to the `fast-glob`  package.

`fast-glob` also allow to define negative patterns, this way this would also be possible without this option. But the way the package `fast-glob` is used this does not work, because all `entryPoints` are passed to the module separately.

Please note:  `fast-glob`  also supports to pass an array of strings directly and no loop is needed, but I don't know if this was implemented this way for some reason.